### PR TITLE
에이전트 순환 기준 완화 및 장르 비율 검증 대상에서 제거

### DIFF
--- a/music_agent/constants.py
+++ b/music_agent/constants.py
@@ -1,5 +1,5 @@
 # 순환 그래프 설정
-MAX_ITERATION_COUNT = 3  # 최대 재시도 횟수
+MAX_ITERATION_COUNT = 2  # 최대 재시도 횟수
 
 # 선곡 설정
 TARGET_FINAL_TRACK_COUNT = 20  # 최종 추천 곡 수
@@ -9,15 +9,15 @@ CONTEXT_TRACK_COUNT = 15  # 상황 기반 선곡 목표 수
 
 # 품질 검증 기준
 MAX_ARTIST_TRACK_COUNT = 4  # 한 아티스트당 최대 곡 수
-MIN_RECENT_TRACK_RATIO = 0.3  # 최소 신곡 비율 (30%)
-MIN_GENRE_MATCH_RATIO = 0.5  # 최소 장르 일치율 (50%)
+MIN_RECENT_TRACK_RATIO = 0.2  # 최소 신곡 비율 (20%)
+MIN_PREFERRED_ARTIST_COUNT = 2  # 최소 선호 아티스트 매칭 수 (3명 중 2명)
 RECENT_TRACK_DAYS = 365  # 신곡 기준 (최근 1년)
 
 # Spotify 검색 설정
 PLAYLIST_SEARCH_LIMIT = 3  # 플레이리스트 검색 개수
 MAX_TRACKS_PER_PLAYLIST = 150  # 플레이리스트당 최대 트랙 수
-ARTIST_SEARCH_LIMIT = 1  # 아티스트 검색 개수
-DEFAULT_TRACK_LIMIT = 10  # 기본 트랙 검색 개수
+ARTIST_SEARCH_LIMIT = 1  # 아티스트 검색 개수, 검색 결과 최대 값
+DEFAULT_TRACK_LIMIT = 15  # 아티스트 별 기본 트랙 검색 결과 개수
 ENHANCED_TRACK_LIMIT = 20  # 재검색 시 트랙 개수
 
 # 필터링 설정

--- a/music_agent/nodes/model_node.py
+++ b/music_agent/nodes/model_node.py
@@ -43,19 +43,10 @@ def context_agent_node(state: AgentState):
 
   if needs_recent_tracks:
       recent_ratio = validation_feedback.get("recent_track_ratio", 0)
-      missing_genres = validation_feedback.get("missing_genres", [])
-
-      feedback_parts = []
 
       if recent_ratio < MIN_RECENT_TRACK_RATIO:
-          feedback_parts.append("신곡 비율이 낮습니다. 'New 2025', 'Latest 2026', 'New Release' 키워드를 포함한 검색어를 생성하세요.")
-
-      if missing_genres:
-          genres_str = ", ".join(missing_genres[:2])  # 최대 2개 장르만
-          feedback_parts.append(f"다음 장르가 부족합니다: {genres_str}. 이 장르를 상황(목표/위치)과 조합한 검색어를 생성하세요.")
-
-      if feedback_parts:
-          additional_instructions = "\n\n[재검색 요청 - 부족한 부분만 보완]\n- " + "\n- ".join(feedback_parts)
+          additional_instructions = "\n\n[재검색 요청 - 부족한 부분만 보완]"
+          additional_instructions += "\n- 신곡 비율이 낮습니다. 'New 2025', 'Latest 2026', 'New Release' 키워드를 포함한 검색어를 생성하세요."
           additional_instructions += "\n\n이번에는 2-3개 검색어만 생성하세요 (부족한 부분 집중 보완)."
 
   sys_msg = SystemMessage(content=SYSTEM_PROMPT + "\n\n" + context_str + additional_instructions)


### PR DESCRIPTION
## 에이전트 순환 기준 완화 및 장르 비율 검증 대상에서 제거

## 문제 상황
- 장르 검증 비율이 너무 높았고, 장르는 적절하게 피드백 과정에 적용 되지 않는 문제점 발견 후 장르 검증 제거
- context_agent 프롬프트를 수정해도 3번 쨰 이상 순환 과정에서 context_agent의 응답 시간이 3초 이상으로 길어지는 현상 발견(프롬프트 누적으로 길어지는 것 같음)

## 개선 내용
- 선호 아티스트 모두의 곡이 아닌 3명중 2명의 곡만 들어가도록 검증 기준 완화
- 최대 순환 횟수 2회로 완호
- 장르 검증 제거
- 신곡 최소 비율 30퍼센트에서 20퍼센트로 수정

## 개선 내용
- 평균적인 응답 속도는 약간의 개선, 주로 5초대 
- 하지만 최저 응답속도, 4초 후반대에 응답이 오는 경우가 있을 정도로 개선